### PR TITLE
Use Jekyll >=3.2.0, jekyll-theme-guides-mbland

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ script: bundle exec jekyll build
 
 language: ruby
 rvm:
-  - 2.2.0
+- 2.4

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
-gem 'redcarpet'
-gem 'rouge'
-gem 'go_script'
+gem 'jekyll', '>=3.2.0'
 
 group :jekyll_plugins do
-  gem 'guides_style_18f'
+  gem 'jekyll-theme-guides-mbland'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,60 +1,63 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    colorator (0.1)
-    ffi (1.9.10)
-    go_script (0.1.5)
-      bundler (~> 1.10)
-      safe_yaml (~> 1.0)
-    guides_style_18f (0.4.2)
-      jekyll
-      jekyll_pages_api
-      jekyll_pages_api_search
-      rouge
-      sass
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
     htmlentities (4.3.4)
-    jekyll (3.0.0)
-      colorator (~> 0.1)
+    jekyll (3.5.2)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
-      liquid (~> 3.0)
+      liquid (~> 4.0)
       mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-sass-converter (1.3.0)
-      sass (~> 3.2)
-    jekyll-watch (1.3.0)
-      listen (~> 3.0)
-    jekyll_pages_api (0.1.5)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-theme-guides-mbland (0.2.1)
+      jekyll (>= 3.2.0)
+      jekyll_pages_api
+      jekyll_pages_api_search
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    jekyll_pages_api (0.1.6)
       htmlentities (~> 4.3)
       jekyll (>= 2.0, < 4.0)
-    jekyll_pages_api_search (0.4.3)
+    jekyll_pages_api_search (0.4.4)
       jekyll_pages_api (~> 0.1.4)
       sass (~> 3.4)
-    kramdown (1.9.0)
-    liquid (3.0.6)
-    listen (3.0.3)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9)
-    mercenary (0.3.5)
-    rb-fsevent (0.9.6)
-    rb-inotify (0.9.5)
-      ffi (>= 0.5.0)
-    redcarpet (3.3.3)
-    rouge (1.10.1)
+    kramdown (1.15.0)
+    liquid (4.0.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.19)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  go_script
-  guides_style_18f
-  jekyll
-  redcarpet
-  rouge
+  jekyll (>= 3.2.0)
+  jekyll-theme-guides-mbland
 
 BUNDLED WITH
-   1.11.2
+   1.15.4

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,4 @@
-markdown: redcarpet
-name: 18F Guides Template
+name: Guides Template
 exclude:
 - CONTRIBUTING.md
 - Gemfile
@@ -9,8 +8,8 @@ exclude:
 - go
 - vendor
 
+theme: jekyll-theme-guides-mbland
 permalink: pretty
-highlighter: rouge
 incremental: true
 
 sass:
@@ -18,12 +17,12 @@ sass:
 
 # Author/Organization info to be displayed in the templates
 author:
-  name: 18F
-  url: https://18f.gsa.gov
+  name: Mike Bland
+  url: https://mike-bland.com/
 
 # Point the logo URL at a file in your repo or hosted elsewhere by your organization
-logourl: /assets/img/18f-logo.png
-logoalt: 18F logo
+# logourl:
+# logoalt:
 
 # To expand all navigation bar entries by default, set this property to true:
 expand_nav: true
@@ -63,13 +62,13 @@ navigation:
 repos:
 - name: Guides Template
   description: Main repository
-  url: https://github.com/18F/guides-template
+  url: https://github.com/mbland/guides-template
 
 back_link:
-  url: "https://pages.18f.gov/guides/"
-  text: Read more 18F Guides
+  url: https://mike-bland.com/
+  text: "Back to Mike Bland's site"
 
-google_analytics_ua: UA-48605964-19
+#google_analytics_ua:
 
 collections:
   pages:
@@ -80,7 +79,7 @@ defaults:
 - scope:
     path: ""
   values:
-    layout: "guides_style_18f_default"
+    layout: "default"
 
 # Configuration for jekyll_pages_api_search plugin gem.
 jekyll_pages_api_search:

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1,4 +1,4 @@
 ---
 ---
 
-@import "guides_style_18f";
+@import "{{ site.theme }}";


### PR DESCRIPTION
Now that Jekyll has proper theme support, `guides_style_mbland` has been refactored and renamed as `jekyll-theme-guides-mbland`.

Also bumps the Ruby version for the Travis build.