### PR TITLE
jekyll-theme-guides-mbland v0.2.3, flat_namespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
-    jekyll-theme-guides-mbland (0.2.2)
+    jekyll-theme-guides-mbland (0.2.3)
       jekyll (>= 3.2.0)
       jekyll_pages_api
       jekyll_pages_api_search

--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,9 @@ author:
 # To expand all navigation bar entries by default, set this property to true:
 expand_nav: true
 
+# To flatten the URL namespace so every other page is a child of the root URL:
+flat_namespace: true
+
 # Navigation
 # List links that should appear in the site sidebar here
 navigation:


### PR DESCRIPTION
This fixes the odd positioning of the breadcrumbs, and demonstrates the `flat_namespace` configuration feature.