### PR TITLE
Bump theme to jekyll-theme-guides-mbland v1.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       safe_yaml (~> 1.0)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
-    jekyll-theme-guides-mbland (1.0.1)
+    jekyll-theme-guides-mbland (1.0.3)
       jekyll (>= 3.2.0)
       jekyll_pages_api
       jekyll_pages_api_search


### PR DESCRIPTION
This picks up a bugfix so that the search components aren't included when search is disabled, and activates anchor.js.
