### PR TITLE
add-links: Mention AnchorJS section header links

### DIFF
--- a/_pages/add-links.md
+++ b/_pages/add-links.md
@@ -15,6 +15,24 @@ used throughout this template. For example:
 [md-links]: https://daringfireball.net/projects/markdown/syntax#link
 ```
 
+### Generating section header links
+
+There's nothing special to do here! Thanks to the magic of [AnchorJS][],
+included as part of the [jekyll-theme-guides-mbland][theme] theme, these links
+are automatically added to `h3` headers and above (i.e. [Markdown lines starting
+with `###`][md-headers]). Hovering over a section header using the mouse reveals
+its link via a small link icon.
+
+[AnchorJS]:   https://www.bryanbraun.com/anchorjs/
+[theme]:      https://rubygems.org/gems/{{site.theme}}
+[md-headers]: https://daringfireball.net/projects/markdown/syntax#header
+
+#### Protip: Only use `h3` headers and above
+
+Since the main document title is a `h1` header, and the document section title
+is a `h2` header, you generally want to use `h3` and above in your `_pages`
+files.
+
 ### Linking to other pages within the guide
 
 Using the [Jekyll `link` tag][jekyll-link], you can include a reference to


### PR DESCRIPTION
Also advises against using `h1` and `h2` headings in the `_pages` files.
