### PR TITLE
Add `site.baseurl` to links, Kramdown section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,6 +44,9 @@ navigation:
   - text: Make a child page
     url: make-a-child-page/
     internal: true
+  - text: Using Kramdown features
+    url: using-kramdown-features/
+    internal: true
 - text: Add links
   url: add-links/
   internal: true

--- a/_pages/add-a-new-page.md
+++ b/_pages/add-a-new-page.md
@@ -71,6 +71,7 @@ contents to learn how to add links to other websites, as well as internal links
 to other pages within your document.
 
 Alternately, you may click _Make a child page_ to see how to make chapters
-appear as children of related chapters.
+appear as children of related chapters, or _Using Kramdown features_ to learn
+about some advanced formatting features.
 
-[update-nav]: {% link _pages/update-the-config-file.md %}#register-pages-in-nav-bar
+[update-nav]: {{ site.baseurl }}{% link _pages/update-the-config-file.md %}#register-pages-in-the-navigation-bar

--- a/_pages/add-a-new-page/make-a-child-page.md
+++ b/_pages/add-a-new-page/make-a-child-page.md
@@ -42,5 +42,5 @@ Click the _Add links_ entry in the table of contents to learn how to add links
 to other websites, as well as internal links to other pages within your
 document.
 
-[add-page]: {% link _pages/add-a-new-page.md %}
-[update-nav]: {% link _pages/update-the-config-file.md %}#register-pages-in-nav-bar
+[add-page]: {{ site.baseurl }}{% link _pages/add-a-new-page.md %}
+[update-nav]: {{ site.baseurl }}{% link _pages/update-the-config-file.md %}#register-pages-in-the-navigation-bar

--- a/_pages/add-a-new-page/using-kramdown-features.md
+++ b/_pages/add-a-new-page/using-kramdown-features.md
@@ -1,0 +1,43 @@
+---
+title: Using Kramdown features
+---
+[Kramdown][], the default Markdown converter used by Jekyll, provides some extra
+features beyond those offered by standard Markdown.
+
+[Kramdown]: https://kramdown.gettalong.org/quickref.html
+
+* Table of contents
+{:toc}
+
+### Adding a table of contents within a page
+
+To generate a table of contents in your pages, add the following placeholder
+somewhere at the top:
+
+```markdown
+* Table of contents
+{:toc}
+```
+
+See the [Automatic “Table of Contents” Generation][toc] section of the Kramdown
+documentation for more details.
+
+[toc]:      https://kramdown.gettalong.org/converter/html.html#toc
+
+### Adding footnotes to a page
+
+Kramdown also supports footnotes that automatically appear at the bottom of the
+page.[^f] You may want to add an empty **Footnotes** section to the bottom of
+your page to contain them. See the [Footnotes section of the Kramdown quick
+reference][ref] for more information.[^r]
+
+[ref]: https://kramdown.gettalong.org/quickref.html#footnotes
+
+[^f]: Reference names in the Markdown source can be anything, and are
+      automatically converted to numbers.
+
+[^r]: There's too little content on this page for the back links from these
+      footnotes to scroll the page, but rest assured the back reference anchors
+      are there.
+
+### Footnotes

--- a/_pages/add-images.md
+++ b/_pages/add-images.md
@@ -8,15 +8,17 @@ that references it.
 
 Now within your documents, you can reference your images as advised by the
 [Accessibility Guide][acc-images], using raw HTML or [Markdown image
-syntax][md-img]:
+syntax][md-img] (adding the `{% raw %}{{ site.baseurl }}{% endraw %}` prefix to
+your links as discussed in the _[Add links][]_ chapter):
 
 [acc-images]: https://accessibility.18f.gov/images/
 [md-img]:     https://daringfireball.net/projects/markdown/syntax#img
 
 ```markdown
-![Example image][img-example]
+![Example of an included image][img-example]
 
-[img-example]: {% raw %}{% link _pages/images.png %}{% endraw %} "Example image"
+[img-example]: {% raw %}{{ site.baseurl }}{% link _pages/images.png %}{% endraw %}
+  "Example of an included image"
 ```
 
 ![Example of an included image][img-example]
@@ -40,4 +42,6 @@ $ optipng -o 9 -strip all _pages/image.png
 
 Click the _Update the config file_ entry in the table of contents.
 
-[img-example]: {% link _pages/images.png %} "Example image"
+[img-example]: {{ site.baseurl }}{% link _pages/images.png %}
+  "Example of an included image"
+[Add links]:   {{ site.baseurl }}{% link _pages/add-links.md %}#linking-to-other-pages-within-the-guide

--- a/_pages/add-links.md
+++ b/_pages/add-links.md
@@ -27,11 +27,12 @@ its link via a small link icon.
 [theme]:      https://rubygems.org/gems/{{site.theme}}
 [md-headers]: https://daringfireball.net/projects/markdown/syntax#header
 
-#### Protip: Only use `h3` headers and above
+#### Only use `h3` headers and above
 
 Since the main document title is a `h1` header, and the document section title
 is a `h2` header, you generally want to use `h3` and above in your `_pages`
-files.
+files. This is why automatic section header links are only available for `h3`
+and above.
 
 ### Linking to other pages within the guide
 
@@ -39,10 +40,14 @@ Using the [Jekyll `link` tag][jekyll-link], you can include a reference to
 another page in your document like so:
 
 ```markdown
-[other-page]: {% raw %}{% link _pages/other-page.md %}{% endraw %}
+[other-page]: {% raw %}{{ site.baseurl }}{% link _pages/other-page.md %}{% endraw %}
 ```
 
 [jekyll-link]: https://jekyllrb.com/docs/templates/#link
+
+Every link to another page _must_ be prefixed with
+`{% raw %}{{ site.baseurl }}{% endraw %}`. If you'd like to know why, see the
+_[Understanding the `baseurl:` property][baseurl]_ page.
 
 For example, this link to the next chapter, [Add images][add-images], appears in
 the Markdown source as:
@@ -51,7 +56,7 @@ the Markdown source as:
 For example, this link to the next chapter, [Add images][add-images], appears in
 the Markdown source as:
 
-[add-images]: {% raw %}{% link _pages/add-images.md %}{% endraw %}
+[add-images]: {% raw %}{{ site.baseurl }}{% link _pages/add-images.md %}{% endraw %}
 ```
 
 #### Protip: Put references containing Jekyll `link` tags at the bottom
@@ -68,4 +73,5 @@ argument of a Jekyll `link` tag as the beginning of an emphasized block.
 Click the _Add images_ entry in the table of contents to learn how to add images
 to your guide.
 
-[add-images]: {% link _pages/add-images.md %}
+[add-images]: {{ site.baseurl }}{% link _pages/add-images.md %}
+[baseurl]:    {{ site.baseurl }}{% link _pages/update-the-config-file/understanding-baseurl.md %}

--- a/_pages/advanced-features.md
+++ b/_pages/advanced-features.md
@@ -110,4 +110,4 @@ same branch" section of the pages-server README][int-ext].
 
 [int-ext]: https://github.com/mbland/pages-server#publishing-to-internal-and-external-sites-from-the-same-branch
 
-[baseurl]: {% link _pages/update-the-config-file/understanding-baseurl.md %}
+[baseurl]: {{ site.baseurl }}{% link _pages/update-the-config-file/understanding-baseurl.md %}

--- a/_pages/github-setup.md
+++ b/_pages/github-setup.md
@@ -83,4 +83,4 @@ Once you've finished the steps to create your new guide repo and push it
 to GitHub, click the _Post your guide_ entry in the table of contents for the
 final steps to publish your guide.
 
-[gh-desc]: {% link images/description.png %} "GitHub repo description and website"
+[gh-desc]: {{ site.baseurl }}{% link images/description.png %} "GitHub repo description and website"

--- a/_pages/post-your-guide.md
+++ b/_pages/post-your-guide.md
@@ -60,8 +60,8 @@ editor][gh-edit]:
 
 Congratulations! Your guide should now be published and accessible to the world!
 
-[gh-settings]: {% link images/gh-settings-button.png %} "GitHub settings page button"
-[gh-default]:  {% link images/gh-default-branch.png %} "GitHub default branch option"
-[gh-webhook]:  {% link images/gh-webhook.png %} "Setting the GitHub webhook"
-[gh-add]:      {% link images/gh-add-guide.png %} "Adding the new Guide"
+[gh-settings]: {{ site.baseurl }}{% link images/gh-settings-button.png %} "GitHub settings page button"
+[gh-default]:  {{ site.baseurl }}{% link images/gh-default-branch.png %} "GitHub default branch option"
+[gh-webhook]:  {{ site.baseurl }}{% link images/gh-webhook.png %} "Setting the GitHub webhook"
+[gh-add]:      {{ site.baseurl }}{% link images/gh-add-guide.png %} "Adding the new Guide"
 [gh-edit]:     https://github.com/mbland/guides/edit/pages/_config.yml

--- a/_pages/update-the-config-file.md
+++ b/_pages/update-the-config-file.md
@@ -61,8 +61,7 @@ For example, the `repos:` entry for this template contains:
 repos:{% for i in site.repos %}
 - name: {{ i.name }}
   description: {{ i.description }}
-  url: {{ i.url }}
-{% endfor %}
+  url: {{ i.url }}{% endfor %}
 ```
 
 For the `description:` property, it's OK to enter something generic like "main
@@ -76,7 +75,8 @@ is written as:
 [repo-url]: {{site.repos[0].url}}
 
 ```markdown
-[{% raw %}{{site.repos[0].name}}{% endraw %} source][repo-url]
+For example, this [{% raw %}{{site.repos[0].name}}{% endraw %} source][repo-url]
+link is written as:
 
 [repo-url]: {% raw %}{{site.repos[0].url}}{% endraw %}
 ```

--- a/_pages/update-the-config-file/understanding-baseurl.md
+++ b/_pages/update-the-config-file/understanding-baseurl.md
@@ -4,26 +4,44 @@ title: Understanding the `baseurl:` property
 __It isn't necessary to update `baseurl:` yourself in most cases. This
 section is not necessary to follow through with the rest of the instructions.__
 
-The `baseurl:` configuration property affects the root URL of your guide when
-served locally on your machine. When published on a site using [pages-server][],
-`baseurl:` is automatically set to the name of your repository, so you don't
-have to do that yourself.
+{% capture reponame %}{{ site.repos[0].url | split:"/" | last }}{% endcapture %}
 
-[pages-server]: https://github.com/mbland/pages-server
+The `baseurl:` configuration property affects the root URL of your Guide. The
+URL of each page in your Guide is relative to the `baseurl:`, which is set to
+`/` by default.
 
-For example, when run locally, the URL for this guide is
-`http://localhost:4000/`. In production, the URL is
-`https://MY-PAGES-HOST/guides-template/`, where `MY-PAGES-HOST` is the domain
-name of your Pages server.
-
-The URLs of the individual section pages are relative to the `baseurl:`. For
-example, the `permalink:` of this page is `{{page.url}}`. The full URL then
+For example, the `permalink:` of this page is `{{page.url}}`.  When
+published to a shared host using [pages-server][], `baseurl:` is automatically
+set to the base name of the repository, i.e. `{{reponame}}`. The full URL then
 becomes:
 
 * `http://localhost:4000{{page.url}}` when served locally
-* `https://MY-PAGES-HOST/guides-template{{page.url}}` when published
+* `https://guides.example.com/guides-template{{page.url}}` when published (where
+  `guides.example.com` is a placeholder for the actual pages-server host)
+
+[pages-server]: https://github.com/mbland/pages-server
+
+### Make all internal links relative to `baseurl:`
+
+This is why the `{% raw %}{{ site.baseurl }}{% endraw %}` prefix is required for
+all internal links, to ensure that they remain correct whether your Guide is
+served:
+
+* locally (e.g. `http://localhost:4000/`),
+* from its own dedicated host (e.g.  `https://{{reponame}}.example.com/`), or
+* from a shared host (e.g.  `https://guides.example.com/{{reponame}}/`).
 
 ### Changing the `baseurl:` when serving locally
 
 If you you do change the `baseurl:` property in the `_config.yml` file,
-**remember to include the trailing '`/`'**.
+**remember to include the leading '`/`'**. At the same time, when serving your
+Guide locally, **remember to include the trailing '`/`' at the end of the
+baseurl**.
+
+For example, to serve the Guides Template locally as
+`http://localhost:4000/guides-template/`, add the following to `_config.yml` and
+restart the server:
+
+```yaml
+baseurl: "/guides-template"
+```

--- a/scripts/detach
+++ b/scripts/detach
@@ -14,6 +14,7 @@ export PAGES_BRANCH="${PAGES_BRANCH:-pages}"
 # List of files that will be removed when `./go detach` is run.
 export TEMPLATE_FILES=()
 TEMPLATE_FILES=('_pages/add-a-new-page/make-a-child-page.md'
+  '_pages/add-a-new-page/using-kramdown-features.md'
   '_pages/add-a-new-page.md'
   '_pages/add-images.md'
   '_pages/add-links.md'


### PR DESCRIPTION
This commit adds `{{ site.baseurl }}` to all internal link references and updates the text to explain why it's necessary. In the process, I also added a new section describing the in-page table of contents and footnote features provided by Kramdown.
