### PR TITLE
tests: Add sample-test.bats

### DIFF
--- a/scripts/detach
+++ b/scripts/detach
@@ -30,7 +30,8 @@ TEMPLATE_FILES=('_pages/add-a-new-page/make-a-child-page.md'
   'images/gh-create-branch.png'
   'images/gh-default-branch.png'
   'images/gh-settings-button.png'
-  'images/gh-webhook.png')
+  'images/gh-webhook.png'
+  'tests/detach.bats')
 
 _detach() {
   @go.critical_section_begin

--- a/tests/detach.bats
+++ b/tests/detach.bats
@@ -22,7 +22,7 @@ __setup() {
     "$TEST_GO_ROOTDIR/images/plugh.png")
   local new_file
 
-  mirror_template_into_test_go_rootdir
+  mirror_repo_into_test_go_rootdir
 
   # Avoid having `./go setup` run.
   if [[ ! -d "$TEST_GO_ROOTDIR/_site" ]]; then
@@ -45,7 +45,8 @@ __setup() {
   . "$_GO_USE_MODULES" 'fileutil'
   local __go_collected_file_paths=()
 
-  @go.collect_file_paths "$TEST_GO_ROOTDIR/"{_pages,images}
+  rm -rf "$TEST_GO_ROOTDIR/"{scripts/go-script-bash,tests/bats}
+  @go.collect_file_paths "$TEST_GO_ROOTDIR/"{_pages,images,scripts,tests}
   lines=("${__go_collected_file_paths[@]}")
   printf -v 'output' '%s\n' "${__go_collected_file_paths[@]}"
   assert_lines_equal \
@@ -55,7 +56,17 @@ __setup() {
     "$TEST_GO_ROOTDIR/_pages/index.md" \
     "$TEST_GO_ROOTDIR/images/plugh.png" \
     "$TEST_GO_ROOTDIR/images/quux.png" \
-    "$TEST_GO_ROOTDIR/images/xyzzy.png"
+    "$TEST_GO_ROOTDIR/images/xyzzy.png" \
+    "$TEST_GO_ROOTDIR/scripts/build" \
+    "$TEST_GO_ROOTDIR/scripts/serve" \
+    "$TEST_GO_ROOTDIR/scripts/setup" \
+    "$TEST_GO_ROOTDIR/scripts/test" \
+    "$TEST_GO_ROOTDIR/scripts/update" \
+    "$TEST_GO_ROOTDIR/scripts/update.d/gems" \
+    "$TEST_GO_ROOTDIR/scripts/update.d/nav" \
+    "$TEST_GO_ROOTDIR/scripts/update.d/theme" \
+    "$TEST_GO_ROOTDIR/tests/environment.bash" \
+    "$TEST_GO_ROOTDIR/tests/sample-test.bats"
 
   parse_navigation_menu
   output="$(<"$TEST_GO_ROOTDIR/_config.yml")"

--- a/tests/environment.bash
+++ b/tests/environment.bash
@@ -4,7 +4,7 @@
 set_bats_test_suite_name "${BASH_SOURCE[0]%/*}"
 remove_bats_test_dirs
 
-mirror_template_into_test_go_rootdir() {
+mirror_repo_into_test_go_rootdir() {
   . "$_GO_USE_MODULES" 'fileutil'
   @go.mirror_directory "$_GO_ROOTDIR" "$TEST_GO_ROOTDIR"
 }

--- a/tests/sample-test.bats
+++ b/tests/sample-test.bats
@@ -1,0 +1,23 @@
+#! /usr/bin/env bats
+#
+# Feel free to update this file and environment.bash with any Bash/Bats based
+# tests you'd like to add to your project.
+
+load environment
+
+TEST_LOG_PATTERN=
+
+setup() {
+  test_filter
+  mirror_repo_into_test_go_rootdir
+}
+
+teardown() {
+  @go.remove_test_go_rootdir
+}
+
+@test "$SUITE: sample test" {
+  run "$TEST_GO_ROOTDIR/go" 'help'
+  assert_success
+  assert_output_matches "Usage: $TEST_GO_ROOTDIR/go"
+}


### PR DESCRIPTION
This works around the problem of `./go setup` failing when there aren't any tests by making sure there's a sample Bats test left behind by default.